### PR TITLE
feat: add support for custom node serializers

### DIFF
--- a/.changeset/tidy-chairs-brake.md
+++ b/.changeset/tidy-chairs-brake.md
@@ -1,0 +1,5 @@
+---
+"remark-stringify-nscode": minor
+---
+
+feat: add support for custom node serializers

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@
     - [`unified().use(remarkStringifyNSCode[, options])`](#unifieduseremarkstringifynscode-options)
       - [`options`](#options)
         - [`options.handlers`](#optionshandlers)
+    - [`all(nodes[, options])`](#allnodes-options)
+      - [`nodes`](#nodes)
+      - [`options`](#options-1)
+    - [`allChildren(node[, options])`](#allchildrennode-options)
+    - [`node`](#node)
+      - [`options`](#options-2)
   - [Syntax](#syntax)
   - [Syntax tree](#syntax-tree)
   - [Types](#types)
@@ -65,8 +71,7 @@ console.log(String(file));
 
 ## API
 
-This package exports no identifiers.
-The default export is `remarkStringifyNSCode`.
+This package exports the identifiers `all` and `allChildren`. The default export is `remarkStringifyNSCode`.
 
 ### `unified().use(remarkStringifyNSCode[, options])`
 
@@ -79,6 +84,30 @@ Configuration (optional).
 ##### `options.handlers`
 
 Custom handlers for serializing markdown. Expects an object with [mdast](https://github.com/syntax-tree/mdast) node types as keys, and functions that take a node of that type and return a string as values.
+
+### `all(nodes[, options])`
+
+Serializes a list of nodes into NSCode.
+
+#### `nodes`
+
+The array of nodes to serialize.
+
+#### `options`
+
+Configuration (optional). Expects an objects with the keys `before`, `after`, and `separator` and string values that respectively indicate the strings to insert before, after, and between the nodes.
+
+### `allChildren(node[, options])`
+
+Serializes the children of the given node into NSCode.
+
+### `node`
+
+The node whose children are to be serialized.
+
+#### `options`
+
+Configuration (optional). Expects an objects with the keys `before`, `after`, and `separator` and string values that respectively indicate the strings to insert before, after, and between the child nodes.
 
 ## Syntax
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
   - [Install](#install)
   - [Use](#use)
   - [API](#api)
-    - [`unified().use(remarkStringifyNSCode)`](#unifieduseremarkstringifynscode)
+    - [`unified().use(remarkStringifyNSCode[, options])`](#unifieduseremarkstringifynscode-options)
+      - [`options`](#options)
+        - [`options.handlers`](#optionshandlers)
   - [Syntax](#syntax)
   - [Syntax tree](#syntax-tree)
   - [Types](#types)
@@ -58,7 +60,7 @@ const file = unified()
 console.log(String(file));
 
 // Output:
-// [b]Hello, world[/b]
+// [b]Hello, world![/b]
 ```
 
 ## API
@@ -66,9 +68,17 @@ console.log(String(file));
 This package exports no identifiers.
 The default export is `remarkStringifyNSCode`.
 
-### `unified().use(remarkStringifyNSCode)`
+### `unified().use(remarkStringifyNSCode[, options])`
 
 Serializes markdown into NSCode.
+
+#### `options`
+
+Configuration (optional).
+
+##### `options.handlers`
+
+Custom handlers for serializing markdown. Expects an object with [mdast](https://github.com/syntax-tree/mdast) node types as keys, and functions that take a node of that type and return a string as values.
 
 ## Syntax
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   ],
   "devDependencies": {
     "@changesets/cli": "^2.26.1",
-    "@types/mdast": "^3.0.11",
     "@typescript-eslint/eslint-plugin": "^5.59.8",
     "@typescript-eslint/parser": "^5.59.8",
     "eslint": "^8.42.0",
@@ -36,6 +35,7 @@
     "vitest": "^0.31.4"
   },
   "dependencies": {
+    "@types/mdast": "^3.0.11",
     "unified": "^10.1.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@types/mdast':
+    specifier: ^3.0.11
+    version: 3.0.11
   unified:
     specifier: ^10.1.2
     version: 10.1.2
@@ -13,9 +16,6 @@ devDependencies:
   '@changesets/cli':
     specifier: ^2.26.1
     version: 2.26.1
-  '@types/mdast':
-    specifier: ^3.0.11
-    version: 3.0.11
   '@typescript-eslint/eslint-plugin':
     specifier: ^5.59.8
     version: 5.59.8(@typescript-eslint/parser@5.59.8)(eslint@8.42.0)(typescript@5.1.3)
@@ -615,7 +615,6 @@ packages:
     resolution: {integrity: sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==}
     dependencies:
       '@types/unist': 2.0.6
-    dev: true
 
   /@types/minimist@1.2.2:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,0 +1,62 @@
+import { allChildren } from "./index.js";
+
+import type { HandlerMap } from "./types.js";
+
+export const defaultHandlers: HandlerMap = {
+  root: (node) => {
+    return allChildren(node, {
+      separator: "\n\n",
+    });
+  },
+  paragraph: (node) => {
+    return allChildren(node);
+  },
+  text: (node) => {
+    return node.value;
+  },
+  emphasis: (node) => {
+    return allChildren(node, {
+      before: "[i]",
+      after: "[/i]",
+    });
+  },
+  strong: (node) => {
+    return allChildren(node, {
+      before: "[b]",
+      after: "[/b]",
+    });
+  },
+  link: (node) => {
+    return allChildren(node, {
+      before: `[url=${node.url}]`,
+      after: "[/url]",
+    });
+  },
+  image: (node) => {
+    return `[img]${node.url}[/img]`;
+  },
+  blockquote: (node) => {
+    return allChildren(node, {
+      before: "[quote]",
+      after: "[/quote]",
+    });
+  },
+  list: (node) => {
+    return allChildren(node, {
+      before: `[${node.ordered ? "list=1" : "list"}]\n`,
+      after: `\n[/list]`,
+      separator: "\n",
+    });
+  },
+  listItem: (node) => {
+    return allChildren(node, {
+      before: "[*]",
+    });
+  },
+  thematicBreak: () => {
+    return "[hr]";
+  },
+  code: (node) => {
+    return `[pre]\n${node.value}\n[/pre]`;
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,17 @@ import { defaultHandlers } from "./defaults.js";
 
 import type { Plugin } from "unified";
 import type { Content, Root } from "mdast";
-import type { SerializationOptions } from "./types.js";
+import type { SerializationOptions, Options, HandlerMap } from "./types.js";
 
-const plugin: Plugin = function remarkStringifyNSCode() {
+let handlers: HandlerMap = defaultHandlers;
+
+const plugin: Plugin<[Options] | []> = function remarkStringifyNSCode(
+  options: Options = {}
+) {
+  if ("handlers" in options) {
+    handlers = { ...handlers, ...options.handlers };
+  }
+
   Object.assign(this, { Compiler: one });
 };
 
@@ -17,7 +25,7 @@ export default plugin;
  * @returns Serialized node.
  */
 const one = (node: Content | Root): string => {
-  const handler = defaultHandlers[node.type];
+  const handler = handlers[node.type];
 
   if (!handler) {
     console.warn(`Unhandled node type: ${node.type}`);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,9 @@
 import type { Content, Root } from "mdast";
 
+export type Options = {
+  handlers?: HandlerMap;
+};
+
 export type HandlerMap = {
   [key in (Content | Root)["type"]]?: (
     node: Extract<Content | Root, { type: key }>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,33 @@
+import type { Content, Root } from "mdast";
+
+export type HandlerMap = {
+  [key in (Content | Root)["type"]]?: (
+    node: Extract<Content | Root, { type: key }>
+  ) => string;
+};
+
+/**
+ * Options for serializing a list of nodes.
+ */
+export type SerializationOptions = {
+  /**
+   * The string to insert before the first node.
+   *
+   * @defaultValue `""`
+   */
+  before?: string;
+
+  /**
+   * The string to insert after the last node.
+   *
+   * @defaultValue `""`
+   */
+  after?: string;
+
+  /**
+   * The string to insert between nodes.
+   *
+   * @defaultValue `""`
+   */
+  separator?: string;
+};

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,7 +1,7 @@
 import { unified } from "unified";
 import remarkParse from "remark-parse";
 import { test, expect } from "vitest";
-import remarkStringifyNSCode from "../dist/index.js";
+import remarkStringifyNSCode, { allChildren } from "../dist/index.js";
 
 test("commonmark", () => {
   const file = unified().use(remarkParse).use(remarkStringifyNSCode)
@@ -78,4 +78,22 @@ Inline code with backticks
 print '3 backticks or'
 print 'indent 4 spaces'
 [/pre]`);
+});
+
+test("custom handlers", () => {
+  const file = unified()
+    .use(remarkParse)
+    .use(remarkStringifyNSCode, {
+      handlers: {
+        emphasis: (node) =>
+          allChildren(node, { before: "[b][i]", after: "[/i][/b]" }),
+        heading: (node) =>
+          allChildren(node, { before: "[b][size=200]", after: "[/size][/b]" }),
+      },
+    })
+    .processSync("*emphasis*\n\n# Heading");
+
+  expect(String(file)).toEqual(
+    "[b][i]emphasis[/i][/b]\n\n[b][size=200]Heading[/size][/b]"
+  );
 });


### PR DESCRIPTION
This PR adds support for custom node serializers via the `options.handlers` options. This is useful for applying custom styling (e.g. inserting anchor links) as well as providing serializers for Markdown elements without a clear NSCode equivalent (notably, headings). For convenience in writing these handlers, an `all` and an `allChildren` function are also exported to more easily recursively serialize child nodes from a handler.

Example usage might look something like:

```js
unified()
  .use(remarkParse)
  .use(remarkStringifyNSCode, {
    handlers: {
      emphasis: (node) =>
        allChildren(node, { before: "[b][i]", after: "[/i][/b]" }),
      heading: (node) =>
        allChildren(node, { before: "[b][size=200]", after: "[/size][/b]" }),
    },
  })
  .processSync("*emphasis*\n\n# Heading");
```

Which produces the output:
```
[b][i]emphasis[/i][/b]

[b][size=200]Heading[/size][/b]
```

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [X] Clearly illustrate what problems this PR would solve.
- [X] Link related issues or PRs that this PR would close, if any, using `closes #number`.
- [X] Ideally, include a test that passes with this PR but fails without it.
- [X] Test your code by running `pnpm test`.
- [X] Lint and format your code by running `pnpm lint` and `pnpm format`.
- [X] If your PR makes a change that should be noted in the changelog, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, and so on.
